### PR TITLE
Fix: Ad Image Incomplete src URL

### DIFF
--- a/app/create/create-ad-form.tsx
+++ b/app/create/create-ad-form.tsx
@@ -89,13 +89,14 @@ export function CreateAdForm({ books, user_id }: CreateAdParams) {
     if (!data)
       return;
 
-    for (const url of imagesUrl) {
+    for (let i = 0; i < imagesUrl.length; i++) {
       await supabase
         .from('advertisement_picture')
         .insert({
           advertisement_id: data[0].id,
           id: undefined,
-          url: url
+          url: imagesUrl[i],
+          isCover: i === 0
         });
     }
 
@@ -213,7 +214,7 @@ export function CreateAdForm({ books, user_id }: CreateAdParams) {
                   />
                 </svg>
                 <p
-                  className="mb-2 text-sm text-gray-500 dark:text-gray-400"
+                  className="mb-2 text-sm text-gray-500 dark:text-gray-400 text-center"
                 >
                   <span className="font-semibold">Clicca per caricare</span> oppure trascina e rilascia
                 </p>

--- a/components/user/ad-preview.tsx
+++ b/components/user/ad-preview.tsx
@@ -1,15 +1,22 @@
 import { Card, CardContent, CardFooter } from "@/components/ui/card";
 import { AdPreview } from "@/types/api";
+import { createBrowserClient } from "@supabase/ssr";
 import Image from "next/image";
 import Link from "next/link";
+
 export function AdPreview({ adPreview }: { adPreview: AdPreview }) {
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL ?? "",
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? ""
+  );
+  
   return (
     <Link href="">
       <Card className="w-auto border-0 p-0 text-center flex  flex-col justify-content-center items-center">
         <CardContent className="p-0">
           <Image
             key={adPreview?.id}
-            src={adPreview?.cover_url!}
+            src={adPreview ? supabase.storage.from("images").getPublicUrl(adPreview.cover_url).data.publicUrl : ""}
             height={300}
             width={150}
             alt={adPreview?.cover_url!}

--- a/components/user/ad-preview.tsx
+++ b/components/user/ad-preview.tsx
@@ -16,7 +16,7 @@ export function AdPreview({ adPreview }: { adPreview: AdPreview }) {
         <CardContent className="p-0">
           <Image
             key={adPreview?.id}
-            src={adPreview ? supabase.storage.from("images").getPublicUrl(adPreview.cover_url).data.publicUrl : ""}
+            src={adPreview?.cover_url ? supabase.storage.from("images").getPublicUrl(adPreview.cover_url).data.publicUrl : ""}
             height={300}
             width={150}
             alt={adPreview?.cover_url!}


### PR DESCRIPTION
Closes #20 

### Change list:
- Now the first image uploaded when creating an ad, is considered the cover
- Use `Supabase` functions to fetch absolute-URL of images in `ad-preview` component

Should we apply this change to any other component?